### PR TITLE
generate-dictionary.bat の JSON ファイルのパスを修正

### DIFF
--- a/generate-dictionary.bat
+++ b/generate-dictionary.bat
@@ -13,8 +13,8 @@ exit
 :generate
 
 rem キャラクター
-call "tool\DictionaryMate" "--input" "data\chara.json" "--output" "%1%2" "--ime" "%2"
-move "%1%2\%2.txt" "%1%2\chara.txt"
+call "tool\DictionaryMate" "--input" "data\playable.json" "--output" "%1%2" "--ime" "%2"
+move "%1%2\%2.txt" "%1%2\playable.txt"
 rem ギルド名
 call "tool\DictionaryMate" "--input" "data\guild.json" "--output" "%1%2" "--ime" "%2"
 move "%1%2\%2.txt" "%1%2\guild.txt"


### PR DESCRIPTION
https://github.com/AioiLight/DictionaryConnect/commit/ca4875fe52677b32a771555ba5496b8a64629377 にて chara.json を playable.json にリネームした際、バッチファイル側の変更漏れがあったようなので修正しました